### PR TITLE
Explicitly disable nunjucks template watching

### DIFF
--- a/tasks/nunjucksTransform.js
+++ b/tasks/nunjucksTransform.js
@@ -18,7 +18,7 @@ module.exports = function (options) {
 
     try {
       //options.name = typeof options.name === 'function' && options.name(file) || file.relative;
-      nunjucks.configure(file.base);
+      nunjucks.configure(file.base, {watch: false});
       file.contents = new Buffer(nunjucks.renderString(file.contents.toString(), options));
     } catch (err) {
       this.emit('error', new Error('nunjucksTransform : error with ' + file.path, err));


### PR DESCRIPTION
Hey,

Is this project still alive? :) 

Anyways, here's the problem, I'm using this module in a gulpfile like this:

```
gulp.task('ngdocs', function() {
  return gulp.src(['./src/module.js', './src/services/*.js'])
    .pipe(ngdocParser())
    .pipe(ngdocFormatter({
      template: './docs/templates/ngdoc.md.nunjucks',
      ngdocSectionsOrder: ['object', 'property', 'method', 'event']
     }))
    .pipe($.concat('index.md'))
    .pipe(gulp.dest('./docs/md'));
});
```

Gulp process hangs after the task is finished and never exits unless I hit ctrl+c. Probably it's happening due to some nunjucks default misconfiguration or something (even though nunjucks doc says that `watch` is `false` by default). Solution is to explicitly disable watch in `nunjucks.configure`.
